### PR TITLE
feat: Add support for unmanaged private dns zone groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.6)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.108)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 
@@ -28,6 +28,7 @@ The following resources are used by this module:
 - [azurerm_mssql_firewall_rule.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_firewall_rule) (resource)
 - [azurerm_mssql_server.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_server) (resource)
 - [azurerm_private_endpoint.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)
+- [azurerm_private_endpoint.this_unmanaged_dns_zone_groups](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)
 - [azurerm_private_endpoint_application_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint_application_security_group_association) (resource)
 - [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [modtm_telemetry.telemetry](https://registry.terraform.io/providers/Azure/modtm/latest/docs/resources/telemetry) (resource)
@@ -613,6 +614,14 @@ map(object({
 ```
 
 Default: `{}`
+
+### <a name="input_private_endpoints_manage_dns_zone_group"></a> [private\_endpoints\_manage\_dns\_zone\_group](#input\_private\_endpoints\_manage\_dns\_zone\_group)
+
+Description: Whether to manage private DNS zone groups with this module. If set to false, you must manage private DNS zone groups externally, e.g. using Azure Policy.
+
+Type: `bool`
+
+Default: `true`
 
 ### <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled)
 

--- a/examples/database/README.md
+++ b/examples/database/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -106,7 +106,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.6)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.108)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/database/main.tf
+++ b/examples/database/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/database_with_existing_server/README.md
+++ b/examples/database_with_existing_server/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -68,7 +68,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.6)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.108)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/database_with_existing_server/main.tf
+++ b/examples/database_with_existing_server/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -72,7 +72,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.6)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.108)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/elastic_pool_database/README.md
+++ b/examples/elastic_pool_database/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -112,7 +112,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.6)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.108)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/elastic_pool_database/main.tf
+++ b/examples/elastic_pool_database/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/elastic_pool_with_existing_server/README.md
+++ b/examples/elastic_pool_with_existing_server/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -81,7 +81,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.6)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.108)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/elastic_pool_with_existing_server/main.tf
+++ b/examples/elastic_pool_with_existing_server/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/mssql_server_with_firewall_rule/README.md
+++ b/examples/mssql_server_with_firewall_rule/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -87,7 +87,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.6)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.108)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/mssql_server_with_firewall_rule/main.tf
+++ b/examples/mssql_server_with_firewall_rule/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/private_endpoint/README.md
+++ b/examples/private_endpoint/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -88,7 +88,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.6)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.108)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/private_endpoint/main.tf
+++ b/examples/private_endpoint/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/private_endpoint_unmanaged_dns/README.md
+++ b/examples/private_endpoint_unmanaged_dns/README.md
@@ -78,6 +78,9 @@ module "sql_server" {
       subnet_resource_id            = azurerm_subnet.this.id
     }
   }
+  # This is required to disable the DNS zone group management.
+  # If you want to manage the DNS zone group externally, ex. with Azure Policy.
+  private_endpoints_manage_dns_zone_group = false
 }
 ```
 

--- a/examples/private_endpoint_unmanaged_dns/README.md
+++ b/examples/private_endpoint_unmanaged_dns/README.md
@@ -1,0 +1,138 @@
+<!-- BEGIN_TF_DOCS -->
+# SQL Server with private endpoint
+
+This deploys the SQL module using a private endpoint.
+
+```hcl
+terraform {
+  required_version = "~> 1.6"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.108"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+# This ensures we have unique CAF compliant names for our resources.
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "0.3.0"
+}
+
+# This is required for resource modules
+resource "azurerm_resource_group" "this" {
+  location = "AustraliaEast"
+  name     = module.naming.resource_group.name_unique
+}
+
+resource "azurerm_virtual_network" "this" {
+  address_space       = ["192.168.0.0/24"]
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.virtual_network.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+}
+
+resource "azurerm_subnet" "this" {
+  address_prefixes     = ["192.168.0.0/24"]
+  name                 = module.naming.subnet.name_unique
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+}
+
+resource "azurerm_private_dns_zone" "this" {
+  name                = "privatelink.vaultcore.azure.net"
+  resource_group_name = azurerm_resource_group.this.name
+}
+
+resource "random_password" "admin_password" {
+  length           = 16
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+  special          = true
+}
+
+# This is the module call
+module "sql_server" {
+  source = "../../"
+  # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
+  # ...
+  enable_telemetry              = false
+  name                          = module.naming.sql_server.name_unique
+  resource_group_name           = azurerm_resource_group.this.name
+  administrator_login           = "mysqladmin"
+  administrator_login_password  = random_password.admin_password.result
+  public_network_access_enabled = false
+  location                      = azurerm_resource_group.this.location
+  server_version                = "12.0"
+  private_endpoints = {
+    primary = {
+      private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
+      subnet_resource_id            = azurerm_subnet.this.id
+    }
+  }
+}
+```
+
+<!-- markdownlint-disable MD033 -->
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.6)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.108)
+
+- <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
+
+## Resources
+
+The following resources are used by this module:
+
+- [azurerm_private_dns_zone.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) (resource)
+- [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
+- [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) (resource)
+- [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) (resource)
+- [random_password.admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) (resource)
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+No required inputs.
+
+## Optional Inputs
+
+No optional inputs.
+
+## Outputs
+
+No outputs.
+
+## Modules
+
+The following Modules are called:
+
+### <a name="module_naming"></a> [naming](#module\_naming)
+
+Source: Azure/naming/azurerm
+
+Version: 0.3.0
+
+### <a name="module_sql_server"></a> [sql\_server](#module\_sql\_server)
+
+Source: ../../
+
+Version:
+
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+<!-- END_TF_DOCS -->

--- a/examples/private_endpoint_unmanaged_dns/README.md
+++ b/examples/private_endpoint_unmanaged_dns/README.md
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -91,7 +91,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.6)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.108)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/private_endpoint_unmanaged_dns/_footer.md
+++ b/examples/private_endpoint_unmanaged_dns/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/private_endpoint_unmanaged_dns/_header.md
+++ b/examples/private_endpoint_unmanaged_dns/_header.md
@@ -1,0 +1,3 @@
+# SQL Server with private endpoint
+
+This deploys the SQL module using a private endpoint.

--- a/examples/private_endpoint_unmanaged_dns/main.tf
+++ b/examples/private_endpoint_unmanaged_dns/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/private_endpoint_unmanaged_dns/main.tf
+++ b/examples/private_endpoint_unmanaged_dns/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_version = "~> 1.6"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.108"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+# This ensures we have unique CAF compliant names for our resources.
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "0.3.0"
+}
+
+# This is required for resource modules
+resource "azurerm_resource_group" "this" {
+  location = "AustraliaEast"
+  name     = module.naming.resource_group.name_unique
+}
+
+resource "azurerm_virtual_network" "this" {
+  address_space       = ["192.168.0.0/24"]
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.virtual_network.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+}
+
+resource "azurerm_subnet" "this" {
+  address_prefixes     = ["192.168.0.0/24"]
+  name                 = module.naming.subnet.name_unique
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+}
+
+resource "azurerm_private_dns_zone" "this" {
+  name                = "privatelink.vaultcore.azure.net"
+  resource_group_name = azurerm_resource_group.this.name
+}
+
+resource "random_password" "admin_password" {
+  length           = 16
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+  special          = true
+}
+
+# This is the module call
+module "sql_server" {
+  source = "../../"
+  # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
+  # ...
+  enable_telemetry              = false
+  name                          = module.naming.sql_server.name_unique
+  resource_group_name           = azurerm_resource_group.this.name
+  administrator_login           = "mysqladmin"
+  administrator_login_password  = random_password.admin_password.result
+  public_network_access_enabled = false
+  location                      = azurerm_resource_group.this.location
+  server_version                = "12.0"
+  private_endpoints = {
+    primary = {
+      private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
+      subnet_resource_id            = azurerm_subnet.this.id
+    }
+  }
+  # This is required to disable the DNS zone group management.
+  # If you want to manage the DNS zone group externally, ex. with Azure Policy as in Enterprise Scale corp, you must set this to false.
+  private_endpoints_manage_dns_zone_group = false
+}

--- a/examples/private_endpoint_unmanaged_dns/main.tf
+++ b/examples/private_endpoint_unmanaged_dns/main.tf
@@ -73,6 +73,6 @@ module "sql_server" {
     }
   }
   # This is required to disable the DNS zone group management.
-  # If you want to manage the DNS zone group externally, ex. with Azure Policy as in Enterprise Scale corp, you must set this to false.
+  # If you want to manage the DNS zone group externally, ex. with Azure Policy.
   private_endpoints_manage_dns_zone_group = false
 }

--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -35,7 +35,7 @@ resource "azurerm_private_endpoint" "this" {
   }
 }
 
-# The PE resource when we are managing **not** the private_dns_zone_group block, such as when using Azure Policy:
+# The PE resource when we are **not** managing the private_dns_zone_group block, such as when using Azure Policy:
 resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
   for_each = { for k, v in var.private_endpoints : k => v if !var.private_endpoints_manage_dns_zone_group }
 

--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -66,8 +66,6 @@ resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
   lifecycle {
     ignore_changes = [private_dns_zone_group]
   }
-
-
 }
 
 resource "azurerm_private_endpoint_application_security_group_association" "this" {

--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -1,6 +1,6 @@
 
 resource "azurerm_private_endpoint" "this" {
-  for_each = var.private_endpoints
+  for_each = { for k, v in var.private_endpoints : k => v if var.private_endpoints_manage_dns_zone_group }
 
   location                      = try(data.azurerm_resource_group.parent[0].location, coalesce(each.value.location, var.location))
   name                          = each.value.name != null ? each.value.name : "pe-${var.name}"
@@ -33,6 +33,41 @@ resource "azurerm_private_endpoint" "this" {
       private_dns_zone_ids = each.value.private_dns_zone_resource_ids
     }
   }
+}
+
+# The PE resource when we are managing **not** the private_dns_zone_group block, such as when using Azure Policy:
+resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
+  for_each = { for k, v in var.private_endpoints : k => v if !var.private_endpoints_manage_dns_zone_group }
+
+  location                      = try(data.azurerm_resource_group.parent[0].location, coalesce(each.value.location, var.location))
+  name                          = each.value.name != null ? each.value.name : "pe-${var.name}"
+  resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
+  subnet_id                     = each.value.subnet_resource_id
+  custom_network_interface_name = each.value.network_interface_name
+  tags                          = each.value.tags
+
+  private_service_connection {
+    is_manual_connection           = false
+    name                           = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "pse-${var.name}"
+    private_connection_resource_id = azurerm_mssql_server.this.id
+    subresource_names              = ["sqlServer"]
+  }
+  dynamic "ip_configuration" {
+    for_each = each.value.ip_configurations
+
+    content {
+      name               = ip_configuration.value.name
+      private_ip_address = ip_configuration.value.private_ip_address
+      member_name        = "sqlServer"
+      subresource_name   = "sqlServer"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [private_dns_zone_group]
+  }
+
+
 }
 
 resource "azurerm_private_endpoint_application_security_group_association" "this" {

--- a/modules/database/README.md
+++ b/modules/database/README.md
@@ -38,7 +38,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.6)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.108)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 ## Resources
 

--- a/modules/database/terraform.tf
+++ b/modules/database/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
   }
 }

--- a/modules/elasticpool/README.md
+++ b/modules/elasticpool/README.md
@@ -38,7 +38,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.6)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.108)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 ## Resources
 

--- a/modules/elasticpool/terraform.tf
+++ b/modules/elasticpool/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108"
+      version = "~> 4.0"
     }
     modtm = {
       source  = "Azure/modtm"

--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,7 @@ variable "diagnostic_settings" {
   default     = {}
   description = <<DESCRIPTION
 A map of diagnostic settings to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
-  
+
 - `name` - (Optional) The name of the diagnostic setting. One will be generated if not set, however this will not be unique if you want to create multiple diagnostic setting resources.
 - `log_categories` - (Optional) A set of log categories to send to the log analytics workspace. Defaults to `[]`.
 - `log_groups` - (Optional) A set of log groups to send to the log analytics workspace. Defaults to `["allLogs"]`.
@@ -73,7 +73,7 @@ variable "lock" {
   default     = null
   description = <<DESCRIPTION
   Controls the Resource Lock configuration for this resource. The following properties can be specified:
-  
+
   - `kind` - (Required) The type of lock. Possible values are `\"CanNotDelete\"` and `\"ReadOnly\"`.
   - `name` - (Optional) The name of the lock. If not specified, a name will be generated based on the `kind` value. Changing this forces the creation of a new resource.
   DESCRIPTION
@@ -92,7 +92,7 @@ variable "managed_identities" {
   default     = {}
   description = <<DESCRIPTION
   Controls the Managed Identity configuration on this resource. The following properties can be specified:
-  
+
   - `system_assigned` - (Optional) Specifies if the System Assigned Managed Identity should be enabled.
   - `user_assigned_resource_ids` - (Optional) Specifies a list of User Assigned Managed Identity resource IDs to be assigned to this resource.
   DESCRIPTION
@@ -145,7 +145,7 @@ variable "private_endpoints" {
   default     = {}
   description = <<DESCRIPTION
   A map of private endpoints to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
-  
+
   - `name` - (Optional) The name of the private endpoint. One will be generated if not set.
   - `role_assignments` - (Optional) A map of role assignments to create on the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time. See `var.role_assignments` for more information.
     - `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
@@ -176,6 +176,13 @@ variable "private_endpoints" {
   nullable    = false
 }
 
+variable "private_endpoints_manage_dns_zone_group" {
+  type        = bool
+  default     = true
+  description = "Whether to manage private DNS zone groups with this module. If set to false, you must manage private DNS zone groups externally, e.g. using Azure Policy."
+  nullable    = false
+}
+
 variable "role_assignments" {
   type = map(object({
     role_definition_id_or_name             = string
@@ -190,7 +197,7 @@ variable "role_assignments" {
   default     = {}
   description = <<DESCRIPTION
   A map of role assignments to create on the <RESOURCE>. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
-  
+
   - `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
   - `principal_id` - The ID of the principal to assign the role to.
   - `description` - (Optional) The description of the role assignment.
@@ -199,7 +206,7 @@ variable "role_assignments" {
   - `condition_version` - (Optional) The version of the condition syntax. Leave as `null` if you are not using a condition, if you are then valid values are '2.0'.
   - `delegated_managed_identity_resource_id` - (Optional) The delegated Azure Resource Id which contains a Managed Identity. Changing this forces a new resource to be created. This field is only used in cross-tenant scenario.
   - `principal_type` - (Optional) The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
-  
+
   > Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
   DESCRIPTION
   nullable    = false


### PR DESCRIPTION
## Description

This PR introduces support for unmanaged private DNS zone groups in private endpoints for SQL Server resources. This feature is particularly useful in enterprise scenarios where DNS zone groups are managed externally (e.g., through Azure Policy).

This change follow the same pattern as implemented in other avm modules, ex: keyvault and container registry.

Key changes:
- Added `private_endpoints_manage_dns_zone_group` variable to control DNS zone group management
- Split private endpoint resource into two variants:
  - One for managed DNS zone groups
  - One for unmanaged DNS zone groups with lifecycle ignore on private_dns_zone_group
- Updated examples to demonstrate unmanaged DNS zone group usage
- Minor improvements to CI/CD workflow scripts

Fixes #[ISSUE_NUMBER] <!-- Replace with actual issue number if applicable -->

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
  - [x] Feature update backwards compatible feature updates
  - [ ] Breaking changes
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks