### PR TITLE
Express Vulnerability Assessment option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.26)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 
@@ -452,6 +452,14 @@ Default: `{}`
 Description: This variable controls whether or not telemetry is enabled for the module.  
 For more information see <https://aka.ms/avm/telemetryinfo>.  
 If it is set to false, then no telemetry will be collected.
+
+Type: `bool`
+
+Default: `false`
+
+### <a name="input_express_vulnerability_assessment_enabled"></a> [express\_vulnerability\_assessment\_enabled](#input\_express\_vulnerability\_assessment\_enabled)
+
+Description: (Optional) Whether the `Express Vulnerability Assessment` feature is enabled for this server. Defaults to `false`.
 
 Type: `bool`
 

--- a/examples/database/main.tf
+++ b/examples/database/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 4.26"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/database_with_existing_server/main.tf
+++ b/examples/database_with_existing_server/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 4.26"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 4.26"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/elastic_pool_database/main.tf
+++ b/examples/elastic_pool_database/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 4.26"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/elastic_pool_with_existing_server/main.tf
+++ b/examples/elastic_pool_with_existing_server/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 4.26"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/mssql_server_with_firewall_rule/main.tf
+++ b/examples/mssql_server_with_firewall_rule/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 4.26"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/private_endpoint/main.tf
+++ b/examples/private_endpoint/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 4.26"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/private_endpoint_unmanaged_dns/main.tf
+++ b/examples/private_endpoint_unmanaged_dns/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 4.26"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ resource "azurerm_mssql_server" "this" {
   public_network_access_enabled                = var.public_network_access_enabled
   tags                                         = var.tags
   transparent_data_encryption_key_vault_key_id = var.transparent_data_encryption_key_vault_key_id
+  express_vulnerability_assessment_enabled     = var.express_vulnerability_assessment_enabled
 
   dynamic "azuread_administrator" {
     for_each = var.azuread_administrator != null ? { this = var.azuread_administrator } : {}

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 4.26"
     }
     modtm = {
       source  = "Azure/modtm"

--- a/variables.sqlserver.tf
+++ b/variables.sqlserver.tf
@@ -62,3 +62,9 @@ variable "transparent_data_encryption_key_vault_key_id" {
   default     = null
   description = "(Optional) The fully versioned `Key Vault` `Key` URL (e.g. `'https://<YourVaultName>.vault.azure.net/keys/<YourKeyName>/<YourKeyVersion>`) to be used as the `Customer Managed Key`(CMK/BYOK) for the `Transparent Data Encryption`(TDE) layer."
 }
+
+variable "express_vulnerability_assessment_enabled" {
+  type        = bool
+  default     = false
+  description = "(Optional) Whether the `Express Vulnerability Assessment` feature is enabled for this server. Defaults to `false`."
+}


### PR DESCRIPTION
## Description

This PR adds the parameter for activating the Express Vulnerability Assessment on the SQL Server.

Since this parameter is only available from azurerm provider version 4.26 onwards (See [azurerm Release Notes](https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v4.26.0)) I've updated the main module, examples and README.

Fixes #98
Closes #98 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
