### PR TITLE
Add support for automatic administrator password generation and Key Vault storage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_mssql_server" "this" {
   resource_group_name                          = var.resource_group_name
   version                                      = var.server_version
   administrator_login                          = var.administrator_login
-  administrator_login_password                 = var.administrator_login_password
+  administrator_login_password = var.generate_administrator_login_password ? (var.administrator_login_password_key_vault_configuration != null ? azurerm_key_vault_secret.administrator_password[0].value : random_password.administrator_password[0].result) : var.administrator_login_password
   connection_policy                            = var.connection_policy
   express_vulnerability_assessment_enabled     = var.express_vulnerability_assessment_enabled
   minimum_tls_version                          = "1.2"
@@ -89,4 +89,24 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
       category = metric.value
     }
   }
+}
+
+# Generate random password when requested
+resource "random_password" "administrator_password" {
+  count   = var.generate_administrator_login_password ? 1 : 0
+  length           = 20
+  min_lower        = 2
+  min_numeric      = 2
+  min_special      = 2
+  min_upper        = 2
+  override_special = "!#$%&()*+,-./:;<=>?@[]^_{|}~"
+  special          = true
+}
+
+# Store password in Key Vault if configuration provided
+resource "azurerm_key_vault_secret" "administrator_password" {
+  count = var.generate_administrator_login_password ? 1 : 0
+  name         = var.administrator_login_password_key_vault_configuration.name
+  value        = random_password.administrator_password[0].result
+  key_vault_id = var.administrator_login_password_key_vault_configuration.key_vault_resource_id
 }

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_mssql_server" "this" {
   resource_group_name                          = var.resource_group_name
   version                                      = var.server_version
   administrator_login                          = var.administrator_login
-  administrator_login_password                 = var.generate_administrator_login_password ? random_password.administrator_password[0].result : var.administrator_login_password
+  administrator_login_password                 = var.administrator_login_password != null ? var.administrator_login_password : (var.generate_administrator_login_password ? random_password.administrator_login_password[0].result : null)
   connection_policy                            = var.connection_policy
   express_vulnerability_assessment_enabled     = var.express_vulnerability_assessment_enabled
   minimum_tls_version                          = "1.2"
@@ -91,10 +91,10 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
   }
 }
 
-# Generate random password when requested
-resource "random_password" "administrator_password" {
-  count   = var.generate_administrator_login_password ? 1 : 0
-  length           = 20
+# Generate random password if generate_administrator_login_password is true
+resource "random_password" "administrator_login_password" {
+  count            = var.generate_administrator_login_password ? 1 : 0
+  length           = 22
   min_lower        = 2
   min_numeric      = 2
   min_special      = 2
@@ -104,9 +104,10 @@ resource "random_password" "administrator_password" {
 }
 
 # Store password in Key Vault if configuration provided
-resource "azurerm_key_vault_secret" "administrator_password" {
-  count = var.generate_administrator_login_password ? 1 : 0
+# Requires that the deployment user has key vault secrets write access
+resource "azurerm_key_vault_secret" "administrator_login_password" {
+  count        = var.administrator_login_password_key_vault_configuration != null ? 1 : 0
+  key_vault_id = var.administrator_login_password_key_vault_configuration.resource_id
   name         = var.administrator_login_password_key_vault_configuration.name
-  value        = random_password.administrator_password[0].result
-  key_vault_id = var.administrator_login_password_key_vault_configuration.key_vault_resource_id
+  value        = azurerm_mssql_server.this.administrator_login_password
 }

--- a/main.tf
+++ b/main.tf
@@ -108,6 +108,6 @@ resource "random_password" "administrator_login_password" {
 resource "azurerm_key_vault_secret" "administrator_login_password" {
   count        = var.administrator_login_password_key_vault_configuration != null ? 1 : 0
   key_vault_id = var.administrator_login_password_key_vault_configuration.resource_id
-  name         = var.administrator_login_password_key_vault_configuration.name
+  name         = administrator_login_password_key_vault_configuration.name != null ? administrator_login_password_key_vault_configuration.name : "${var.name}-${var.administrator_login}-password"
   value        = azurerm_mssql_server.this.administrator_login_password
 }

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_mssql_server" "this" {
   resource_group_name                          = var.resource_group_name
   version                                      = var.server_version
   administrator_login                          = var.administrator_login
-  administrator_login_password = var.generate_administrator_login_password ? (var.administrator_login_password_key_vault_configuration != null ? azurerm_key_vault_secret.administrator_password[0].value : random_password.administrator_password[0].result) : var.administrator_login_password
+  administrator_login_password                 = var.generate_administrator_login_password ? random_password.administrator_password[0].result : var.administrator_login_password
   connection_policy                            = var.connection_policy
   express_vulnerability_assessment_enabled     = var.express_vulnerability_assessment_enabled
   minimum_tls_version                          = "1.2"

--- a/main.tf
+++ b/main.tf
@@ -103,11 +103,17 @@ resource "random_password" "administrator_login_password" {
   special          = true
 }
 
-# Store administrator_login_password in Key Vault if administrator_login_password_key_vault_configuration is provided
-# Requires that the deployment user has key vault secrets write access
+# Store administrator_login_password in kv if administrator_login_password_key_vault_configuration is provided
+# Requires that the deployment user has kv secrets write access
 resource "azurerm_key_vault_secret" "administrator_login_password" {
   count        = var.administrator_login_password_key_vault_configuration != null ? 1 : 0
   key_vault_id = var.administrator_login_password_key_vault_configuration.resource_id
-  name         = var.administrator_login_password_key_vault_configuration.name != null ? var.administrator_login_password_key_vault_configuration.name : "${var.name}-${var.administrator_login}-password"
   value        = azurerm_mssql_server.this.administrator_login_password
+
+# Use the provided kv secret name, or a default if not provided
+  name = (
+    var.administrator_login_password_key_vault_configuration.name != null
+      ? var.administrator_login_password_key_vault_configuration.name
+      : "${var.name}-${var.administrator_login}-password"
+  )
 }

--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,7 @@ resource "random_password" "administrator_login_password" {
   special          = true
 }
 
-# Store password in Key Vault if configuration provided
+# Store administrator_login_password in Key Vault if administrator_login_password_key_vault_configuration is provided
 # Requires that the deployment user has key vault secrets write access
 resource "azurerm_key_vault_secret" "administrator_login_password" {
   count        = var.administrator_login_password_key_vault_configuration != null ? 1 : 0

--- a/main.tf
+++ b/main.tf
@@ -108,6 +108,6 @@ resource "random_password" "administrator_login_password" {
 resource "azurerm_key_vault_secret" "administrator_login_password" {
   count        = var.administrator_login_password_key_vault_configuration != null ? 1 : 0
   key_vault_id = var.administrator_login_password_key_vault_configuration.resource_id
-  name         = administrator_login_password_key_vault_configuration.name != null ? administrator_login_password_key_vault_configuration.name : "${var.name}-${var.administrator_login}-password"
+  name         = var.administrator_login_password_key_vault_configuration.name != null ? var.administrator_login_password_key_vault_configuration.name : "${var.name}-${var.administrator_login}-password"
   value        = azurerm_mssql_server.this.administrator_login_password
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,11 +9,13 @@ output "private_endpoints" {
 output "resource" {
   description = "This is the full output for the resource."
   value       = azurerm_mssql_server.this
+  sensitive   = true
 }
 
 output "resource_databases" {
   description = "A map of databases. The map key is the supplied input to var.databases. The map value is the entire azurerm_mssql_database resource."
   value       = module.database
+  sensitive   = true
 }
 
 output "resource_elasticpools" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,3 +32,9 @@ output "resource_name" {
   description = "This is the name of the resource."
   value       = azurerm_mssql_server.this.name
 }
+
+output "generated_administrator_login_password" {
+  description = "The generated administrator login password (only when generate_administrator_login_password is true)"
+  value       = var.generate_administrator_login_password ? random_password.administrator_password[0].result : null
+  sensitive   = true
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,13 +9,11 @@ output "private_endpoints" {
 output "resource" {
   description = "This is the full output for the resource."
   value       = azurerm_mssql_server.this
-  sensitive   = true  # This LoC addresses https://github.com/Azure/terraform-azurerm-avm-res-sql-server/issues/103
 }
 
 output "resource_databases" {
   description = "A map of databases. The map key is the supplied input to var.databases. The map value is the entire azurerm_mssql_database resource."
   value       = module.database
-  sensitive   = true  # This LoC addresses https://github.com/Azure/terraform-azurerm-avm-res-sql-server/issues/103
 }
 
 output "resource_elasticpools" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,13 +9,13 @@ output "private_endpoints" {
 output "resource" {
   description = "This is the full output for the resource."
   value       = azurerm_mssql_server.this
-  sensitive   = true
+  sensitive   = true  # This LoC addresses https://github.com/Azure/terraform-azurerm-avm-res-sql-server/issues/103
 }
 
 output "resource_databases" {
   description = "A map of databases. The map key is the supplied input to var.databases. The map value is the entire azurerm_mssql_database resource."
   value       = module.database
-  sensitive   = true
+  sensitive   = true  # This LoC addresses https://github.com/Azure/terraform-azurerm-avm-res-sql-server/issues/103
 }
 
 output "resource_elasticpools" {
@@ -33,7 +33,7 @@ output "resource_name" {
   value       = azurerm_mssql_server.this.name
 }
 
-output "generated_administrator_login_password" {
+output "sql_server_generated_administrator_login_password" {
   description = "The generated administrator login password (only when generate_administrator_login_password is true)"
   value       = var.generate_administrator_login_password ? random_password.administrator_password[0].result : null
   sensitive   = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,9 +32,3 @@ output "resource_name" {
   description = "This is the name of the resource."
   value       = azurerm_mssql_server.this.name
 }
-
-output "sql_server_generated_administrator_login_password" {
-  description = "The generated administrator login password (only when generate_administrator_login_password is true)"
-  value       = var.generate_administrator_login_password ? random_password.administrator_password[0].result : null
-  sensitive   = true
-}

--- a/variables.sqlserver.tf
+++ b/variables.sqlserver.tf
@@ -33,7 +33,7 @@ variable "administrator_login_password_key_vault_configuration" {
 (Optional) Configuration for storing the SQL Server administrator login password as a secret in Azure Key Vault. If not provided, the password will not be stored in Key Vault as part of this module.
 
 - `resource_id`: string (required) = (required) The resource ID of the Key Vault where the credentials will be stored.
-- `name`: string (optional, default: null) = (optional) The name of the secret in the Key Vault. If not provided, a name will be generated using the pattern '<sql server name>-<administrator_login>-password'.
+- `name`: string (optional, default: null) = (optional) The name of the secret in the Key Vault. If not provided, a name will be generated using the pattern '<sql server name>-<administrator login name>-password'.
 EOT
 }
 

--- a/variables.sqlserver.tf
+++ b/variables.sqlserver.tf
@@ -13,23 +13,28 @@ variable "administrator_login" {
 variable "administrator_login_password" {
   type        = string
   default     = null
-  description = "(Optional) The password associated with the `administrator_login` user. Needs to comply with Azure's [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx). Required unless `azuread_authentication_only` in the `azuread_administrator` block is `true`."
+  description = "(Optional) The password associated with the `administrator_login` user. Needs to comply with Azure's [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx). Required unless `generate_administrator_login_password` is `true`, or `azuread_authentication_only` in the `azuread_administrator` block is `true`. If `administrator_login_password` is specified, it takes priority over `generate_administrator_login_password`."
   sensitive   = true
 }
 
 variable "generate_administrator_login_password" {
   type        = bool
   default     = false
-  description = "(Optional) Whether to generate a random administrator login password. If true, the password will be generated and optionally stored in Key Vault using administrator_login_password_key_vault_configuration"
+  description = "(Optional) Specifies whether a password should be randomly generated for the `administrator_login` user. Required unless `administrator_login_password` is explicitly set, or `azuread_authentication_only` in the `azuread_administrator` block is `true`. If `administrator_login_password` is specified, it takes priority over `generate_administrator_login_password`."
 }
 
 variable "administrator_login_password_key_vault_configuration" {
   type = object({
-    key_vault_resource_id = string
-    name                  = optional(string, sql-server-administrator_login_password)
+    resource_id = string
+    name = optional(string, "${var.name}-${var.administrator_login}-password")
   })
-  default     = null
-  description = "Configuration for storing the generated administrator password in Key Vault. Only used when generate_administrator_login_password is true."
+  default = null
+  description = <<-EOT
+(Optional) Configuration for storing the SQL Server administrator login password as a secret in Azure Key Vault. If not provided, the password will not be stored in Key Vault as part of this module.
+
+- `resource_id`: string (required) = (required) The resource ID of the Key Vault where the credentials will be stored.
+- `name`: string (optional, default: null) = (optional) The name of the secret in the Key Vault. If not provided, a name will be generated using the pattern '<sql server name>-<administrator_login>-password'.
+EOT
 }
 
 variable "azuread_administrator" {

--- a/variables.sqlserver.tf
+++ b/variables.sqlserver.tf
@@ -26,7 +26,7 @@ variable "generate_administrator_login_password" {
 variable "administrator_login_password_key_vault_configuration" {
   type = object({
     resource_id = string
-    name = optional(string, "${var.name}-${var.administrator_login}-password")
+    name = optional(string, null)
   })
   default = null
   description = <<-EOT

--- a/variables.sqlserver.tf
+++ b/variables.sqlserver.tf
@@ -20,7 +20,7 @@ variable "administrator_login_password" {
 variable "generate_administrator_login_password" {
   type        = bool
   default     = false
-  description = "(Optional) Specifies whether a password should be randomly generated for the `administrator_login` user. Required unless `administrator_login_password` is explicitly set, or `azuread_authentication_only` in the `azuread_administrator` block is `true`. If `administrator_login_password` is specified, it takes priority over `generate_administrator_login_password`."
+  description = "(Optional) Specifies whether a random password should be generated for the `administrator_login` user. Required unless `administrator_login_password` is explicitly set, or `azuread_authentication_only` in the `azuread_administrator` block is `true`. If `administrator_login_password` is specified, it takes priority over `generate_administrator_login_password`."
 }
 
 variable "administrator_login_password_key_vault_configuration" {

--- a/variables.sqlserver.tf
+++ b/variables.sqlserver.tf
@@ -29,11 +29,13 @@ variable "administrator_login_password_key_vault_configuration" {
     name = optional(string, null)
   })
   default = null
-  description = <<-EOT
-(Optional) Configuration for storing the SQL Server administrator login password as a secret in Azure Key Vault. If not provided, the password will not be stored in Key Vault as part of this module.
+description = <<-EOT
+(Optional) An object to configure storing the SQL Server administrator password as a secret in Azure Key Vault (KV).
+If omitted, the password won’t be saved in KV.
 
-- `resource_id`: string (required) = (required) The resource ID of the Key Vault where the credentials will be stored.
-- `name`: string (optional, default: null) = (optional) The name of the secret in the Key Vault. If not provided, a name will be generated using the pattern '<sql server name>-<administrator login name>-password'.
+ - `resource_id` - (Required) The resource ID of the KV where the secret will be stored. Deployment user needs KV secrets write access.
+ - `name` - (Optional) Name of the KV secret. Defaults to '<server name>-<administrator login password>-password' if not provided.
+
 EOT
 }
 

--- a/variables.sqlserver.tf
+++ b/variables.sqlserver.tf
@@ -13,18 +13,24 @@ variable "administrator_login" {
 variable "administrator_login_password" {
   type        = string
   default     = null
-  description = "(Optional) The password associated with the `administrator_login` user. Needs to comply with Azure's [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx). Required unless `generate_administrator_login_password` is `true`, or `azuread_authentication_only` in the `azuread_administrator` block is `true`. If `administrator_login_password` is specified, it takes priority over `generate_administrator_login_password`."
   sensitive   = true
+  description = <<-EOT
+(Optional) The password associated with the `administrator_login` user. Needs to comply with Azure's [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx).
+Required unless `generate_administrator_login_password` is `true`, or `azuread_authentication_only` in the `azuread_administrator` block is `true`.
+If `administrator_login_password` is provided, it takes priority over `generate_administrator_login_password`."
+
+EOT
 }
 
 variable "generate_administrator_login_password" {
   type        = bool
   default     = false
   description = <<-EOT
-    (Optional) Specifies whether a random password should be generated for the `administrator_login` user.
-    Required unless `administrator_login_password` is provided, or `azuread_authentication_only` in the `azuread_administrator` block is `true`.
-    If `administrator_login_password` is specified, it takes priority over `generate_administrator_login_password`.
-  EOT
+(Optional) Specifies whether a random password should be generated for the `administrator_login` user.
+Required unless `administrator_login_password` is provided, or `azuread_authentication_only` in the `azuread_administrator` block is `true`.
+If `administrator_login_password` is specified, it takes priority over `generate_administrator_login_password`.
+
+EOT
 }
 
 
@@ -35,12 +41,13 @@ variable "administrator_login_password_key_vault_configuration" {
   })
   default = null
   description = <<-EOT
-    (Optional) An object to configure storing the SQL Server administrator password as a secret in Azure Key Vault (KV).
-    If omitted, the password won’t be saved in KV.
+(Optional) An object to configure storing the SQL Server administrator password as a secret in Azure Key Vault (KV).
+If omitted, the password won’t be saved in KV.
 
-    - `resource_id` - (Required) The resource ID of the KV where the secret will be stored. Deployment user needs KV secrets write access.
-    - `name` - (Optional) Name of the KV secret. Defaults to '<server name>-<administrator login password>-password' if not provided.
-  EOT
+- `resource_id` - (Required) The resource ID of the KV where the secret will be stored. Deployment user needs KV secrets write access.
+- `name` - (Optional) Name of the KV secret. Defaults to '<server name>-<administrator login password>-password' if not provided.
+
+EOT
 }
 
 variable "azuread_administrator" {

--- a/variables.sqlserver.tf
+++ b/variables.sqlserver.tf
@@ -17,6 +17,20 @@ variable "administrator_login_password" {
   sensitive   = true
 }
 
+variable "generate_administrator_login_password" {
+  type        = bool
+  default     = false
+  description = "(Optional) Whether to generate a random administrator login password. If true, the password will be generated and optionally stored in Key Vault using administrator_login_password_key_vault_configuration"
+}
+variable "administrator_login_password_key_vault_configuration" {
+  type = object({
+    key_vault_resource_id          = string
+    name                           = optional(string, null)
+  })
+  default     = null
+  description = "Configuration for storing the generated administrator password in Key Vault. Only used when generate_administrator_login_password is true."
+}
+
 variable "azuread_administrator" {
   type = object({
     azuread_authentication_only = optional(bool)
@@ -68,3 +82,4 @@ variable "transparent_data_encryption_key_vault_key_id" {
   default     = null
   description = "(Optional) The fully versioned `Key Vault` `Key` URL (e.g. `'https://<YourVaultName>.vault.azure.net/keys/<YourKeyName>/<YourKeyVersion>`) to be used as the `Customer Managed Key`(CMK/BYOK) for the `Transparent Data Encryption`(TDE) layer."
 }
+

--- a/variables.sqlserver.tf
+++ b/variables.sqlserver.tf
@@ -82,4 +82,3 @@ variable "transparent_data_encryption_key_vault_key_id" {
   default     = null
   description = "(Optional) The fully versioned `Key Vault` `Key` URL (e.g. `'https://<YourVaultName>.vault.azure.net/keys/<YourKeyName>/<YourKeyVersion>`) to be used as the `Customer Managed Key`(CMK/BYOK) for the `Transparent Data Encryption`(TDE) layer."
 }
-

--- a/variables.sqlserver.tf
+++ b/variables.sqlserver.tf
@@ -22,10 +22,11 @@ variable "generate_administrator_login_password" {
   default     = false
   description = "(Optional) Whether to generate a random administrator login password. If true, the password will be generated and optionally stored in Key Vault using administrator_login_password_key_vault_configuration"
 }
+
 variable "administrator_login_password_key_vault_configuration" {
   type = object({
-    key_vault_resource_id          = string
-    name                           = optional(string, null)
+    key_vault_resource_id = string
+    name                  = optional(string, sql-server-administrator_login_password)
   })
   default     = null
   description = "Configuration for storing the generated administrator password in Key Vault. Only used when generate_administrator_login_password is true."

--- a/variables.sqlserver.tf
+++ b/variables.sqlserver.tf
@@ -20,8 +20,13 @@ variable "administrator_login_password" {
 variable "generate_administrator_login_password" {
   type        = bool
   default     = false
-  description = "(Optional) Specifies whether a random password should be generated for the `administrator_login` user. Required unless `administrator_login_password` is explicitly set, or `azuread_authentication_only` in the `azuread_administrator` block is `true`. If `administrator_login_password` is specified, it takes priority over `generate_administrator_login_password`."
+  description = <<-EOT
+    (Optional) Specifies whether a random password should be generated for the `administrator_login` user.
+    Required unless `administrator_login_password` is provided, or `azuread_authentication_only` in the `azuread_administrator` block is `true`.
+    If `administrator_login_password` is specified, it takes priority over `generate_administrator_login_password`.
+  EOT
 }
+
 
 variable "administrator_login_password_key_vault_configuration" {
   type = object({
@@ -29,14 +34,13 @@ variable "administrator_login_password_key_vault_configuration" {
     name = optional(string, null)
   })
   default = null
-description = <<-EOT
-(Optional) An object to configure storing the SQL Server administrator password as a secret in Azure Key Vault (KV).
-If omitted, the password won’t be saved in KV.
+  description = <<-EOT
+    (Optional) An object to configure storing the SQL Server administrator password as a secret in Azure Key Vault (KV).
+    If omitted, the password won’t be saved in KV.
 
- - `resource_id` - (Required) The resource ID of the KV where the secret will be stored. Deployment user needs KV secrets write access.
- - `name` - (Optional) Name of the KV secret. Defaults to '<server name>-<administrator login password>-password' if not provided.
-
-EOT
+    - `resource_id` - (Required) The resource ID of the KV where the secret will be stored. Deployment user needs KV secrets write access.
+    - `name` - (Optional) Name of the KV secret. Defaults to '<server name>-<administrator login password>-password' if not provided.
+  EOT
 }
 
 variable "azuread_administrator" {


### PR DESCRIPTION
## Description
This PR adds two new module parameters:

- `generate_administrator_login_password`
- `administrator_login_password_key_vault_configuration`

This PR follows precedents present within the [Virtual Machine AVM](https://registry.terraform.io/modules/Azure/avm-res-compute-virtualmachine/azurerm/latest), namely:
- `generate_admin_password_or_ssh_key`
- `key_vault_configuration`

Closes #111 

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
